### PR TITLE
Create Metayork.sol

### DIFF
--- a/Metayork.sol
+++ b/Metayork.sol
@@ -1,0 +1,22 @@
+// 0.5.1-c8a2
+// Enable optimization
+pragma solidity ^0.5.0;
+
+import "./TRC20.sol";
+import "./TRC20Detailed.sol";
+
+/**
+ * @title SimpleToken
+ * @dev Very simple TRC20 Token example, where all tokens are pre-assigned to the creator.
+ * Note they can later distribute these tokens as they wish using `transfer` and other
+ * `TRC20` functions.
+ */
+contract Token is TRC20, TRC20Detailed {
+
+    /**
+     * @dev Constructor that gives msg.sender all of existing tokens.
+     */
+    constructor () public TRC20Detailed("Metayork", "MYork", 0) {
+        _mint(msg.sender, 10000000000 * (10 ** uint256(decimals())));
+    }
+}


### PR DESCRIPTION
Meta York (MYork) is offered as the main currency to buy and sell in York Land as well as the coin of meta-construction and meta-real estate and physical real estate trade. 